### PR TITLE
AA-228

### DIFF
--- a/ShimmerAndroidInstrumentDriver/ShimmerAndroidInstrumentDriver/src/main/java/com/shimmerresearch/android/Shimmer.java
+++ b/ShimmerAndroidInstrumentDriver/ShimmerAndroidInstrumentDriver/src/main/java/com/shimmerresearch/android/Shimmer.java
@@ -1005,8 +1005,9 @@ public class Shimmer extends ShimmerBluetooth{
 		if (mIsInitialised == false){
 			//only do this during the initialization process to indicate that it is fully initialized, dont do this for a normal inqiuiry
 			mIsInitialised = true;
-			//This is sent when device is first connected:
-			Bundle bundle = new Bundle();
+			//AA-228, this is sent when device is first connected:
+            mIsInquiryDone = false; //To prevent "is ready for Streaming" being sent twice
+            Bundle bundle = new Bundle();
 			bundle.putString(TOAST, "Device " + mMyBluetoothAddress +" is ready for Streaming");
 			sendMsgToHandlerList(MESSAGE_TOAST, bundle);
 		}


### PR DESCRIPTION
1. Refactored code to send "ready for streaming" Toast messages to two places:
a) When first initialised, i.e. when device is first connected
b) After inquiry is done, only when number of remaining commands in buffer is 1, because that is when device is actually ready for streaming
2. Minor code tidy in Shimmer class